### PR TITLE
Fix the deadlock of ffmpeg process on Windows

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Chromaprint.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Chromaprint.cs
@@ -114,9 +114,14 @@ public static class Chromaprint
 
         var info = new ProcessStartInfo(ffmpegPath, args)
         {
+            WindowStyle = ProcessWindowStyle.Hidden,
             CreateNoWindow = true,
+            UseShellExecute = false,
+            ErrorDialog = false,
+
+            // We only consume standardOutput.
             RedirectStandardOutput = true,
-            RedirectStandardError = true
+            RedirectStandardError = false
         };
 
         var ffmpeg = new Process
@@ -125,7 +130,6 @@ public static class Chromaprint
         };
 
         ffmpeg.Start();
-        ffmpeg.WaitForExit(timeout);
 
         using (MemoryStream ms = new MemoryStream())
         {
@@ -138,6 +142,8 @@ public static class Chromaprint
                 ms.Write(buf, 0, bytesRead);
             }
             while (bytesRead > 0);
+
+            ffmpeg.WaitForExit(timeout);
 
             return ms.ToArray().AsSpan();
         }


### PR DESCRIPTION
I've just tried this plugin on Jellyfin 10.8.0 Windows build and it seems that ffmpeg process ran into the deadlock issue. The progress bar of intro-skipper task stuck at 0%.

**Changes**
- Fix the deadlock of ffmpeg process on Windows

I haven't tested this on Linux but I think it should work fine too.