### PR TITLE
Fix script to support older versions of chrome

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Configuration/inject.js
@@ -173,7 +173,7 @@ introSkipper.injectButton = async function () {
 /** Playback position changed, check if the skip button needs to be displayed. */
 introSkipper.videoPositionChanged = function () {
     // Ensure a skip segment was found.
-    if (!introSkipper.skipSegments?.Valid) {
+    if (!introSkipper.skipSegments || !introSkipper.skipSegments.Valid) {
         return;
     }
 


### PR DESCRIPTION
Fix script to work on chromium 79 and older which does not have support for optional chaining. This fixes LG WebOS 6.0 and 5.0 (Closes #113)