### PR TITLE
Add multi-arch container image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: intro-skipper-${{ github.sha }}.dll
         path: ConfusedPolarBear.Plugin.IntroSkipper/bin/Debug/net6.0/ConfusedPolarBear.Plugin.IntroSkipper.dll

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,7 +9,6 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/jellyfin-intro-skipper
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,102 +22,101 @@ jobs:
         jellyfin-version: [10.8.9]
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Get npm cache directory
-      id: npm-cache-dir
-      run: |
-        echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: |
+          echo "dir=$(npm config get cache)" >> $GITHUB_OUTPUT
 
-    - name: Configure npm cache
-      uses: actions/cache@v3
-      id: npm-cache
-      with:
-        path: ${{ steps.npm-cache-dir.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
+      - name: Configure npm cache
+        uses: actions/cache@v3
+        id: npm-cache
+        with:
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
 
-    - name: Checkout modified web interface
-      uses: actions/checkout@v3
-      with:
-        repository: ConfusedPolarBear/jellyfin-web
-        ref: intros
-        path: web
+      - name: Checkout modified web interface
+        uses: actions/checkout@v3
+        with:
+          repository: ConfusedPolarBear/jellyfin-web
+          ref: intros
+          path: web
 
-    - name: Store commit of web interface
-      id: web-commit
-      run: |
-        cd web
-        echo "commit=$(git log -1 --format='%H' | cut -c -10)" >> $GITHUB_OUTPUT
+      - name: Store commit of web interface
+        id: web-commit
+        run: |
+          cd web
+          echo "commit=$(git log -1 --format='%H' | cut -c -10)" >> $GITHUB_OUTPUT
 
-    - name: Build and copy web interface
-      run: |
-        cd web
-        npm install
-        cp -r dist ../docker/
-        tar czf dist.tar.gz dist
+      - name: Build and copy web interface
+        run: |
+          cd web
+          npm install
+          cp -r dist ../docker/
+          tar czf dist.tar.gz dist
 
-    - name: Upload web interface
-      uses: actions/upload-artifact@v3.1.2
-      with:
-        name: jellyfin-web-10.8.0+${{ steps.web-commit.outputs.commit }}.tar.gz
-        path: web/dist.tar.gz
-        if-no-files-found: error
+      - name: Upload web interface
+        uses: actions/upload-artifact@v3.1.2
+        with:
+          name: jellyfin-web-10.8.0+${{ steps.web-commit.outputs.commit }}.tar.gz
+          path: web/dist.tar.gz
+          if-no-files-found: error
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Setup Docker buildx
-      uses: docker/setup-buildx-action@v2
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
 
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into ghcr.io registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-    # Login against a Docker registry except on PR
-    # https://github.com/docker/login-action
-    - name: Log into ghcr.io registry
-      if: github.event_name != 'pull_request'
-      uses: docker/login-action@v2.1.0
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type-raw,value=${{ steps.web-commit.outputs.commit }}
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}},value=${{ matrix.jellyfin-version }}
 
-    # Extract metadata (tags, labels) for Docker
-    # https://github.com/docker/metadata-action
-    - name: Extract Docker metadata
-      id: meta
-      uses: docker/metadata-action@v4
-      with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-        tags: |
-          type-raw,value=${{ steps.web-commit.outputs.commit }}
-          type=raw,value=latest,enable={{is_default_branch}}
-          type=semver,pattern={{version}},value=${{ matrix.jellyfin-version }}
-
-    # Build and push Docker image with Buildx
-    # https://github.com/docker/build-push-action
-    - name: Publish container image
-      id: build-and-push
-      uses: docker/build-push-action@v4.0.0
-      with:
-        file: docker/Dockerfile
-        context: docker
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          JELLYFIN_TAG=${{ matrix.jellyfin-version }}
-        platforms: |
-          linux/amd64
-          linux/arm/v7
-          linux/arm64/v8
-        push: ${{ github.event_name != 'pull_request' }}
-        pull: true
-        no-cache: true
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
-        provenance: false
+      # Build and push Docker image with Buildx
+      # https://github.com/docker/build-push-action
+      - name: Publish container image
+        id: build-and-push
+        uses: docker/build-push-action@v4.0.0
+        with:
+          file: docker/Dockerfile
+          context: docker
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            JELLYFIN_TAG=${{ matrix.jellyfin-version }}
+          platforms: |
+            linux/amd64
+            linux/arm/v7
+            linux/arm64/v8
+          push: ${{ github.event_name != 'pull_request' }}
+          pull: true
+          no-cache: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,11 +7,13 @@ on:
 
 env:
   REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/jellyfin-intro-skipper
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       packages: write
 
     strategy:
@@ -68,16 +70,17 @@ jobs:
         tar czf dist.tar.gz dist
 
     - name: Upload web interface
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: jellyfin-web-10.8.0+${{ steps.web-commit.outputs.commit }}.tar.gz
         path: web/dist.tar.gz
         if-no-files-found: error
 
     - name: Publish container
-      uses: docker/build-push-action@v3.2.0
+      uses: docker/build-push-action@v4.0.0
       with:
         file: docker/Dockerfile
         context: docker/
         push: true
-        tags: ${{ env.REGISTRY}}/confusedpolarbear/jellyfin-intro-skipper:${{ steps.web-commit.outputs.commit }}
+        tags: ${{ env.REGISTRY}}/${{ github.repository.owner }}/jellyfin-intro-skipper:${{ steps.web-commit.outputs.commit }}
+        provenance: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
+        jellyfin-version: [10.8.9]
 
     steps:
     - uses: actions/checkout@v3
@@ -80,7 +81,9 @@ jobs:
       uses: docker/build-push-action@v4.0.0
       with:
         file: docker/Dockerfile
-        context: docker/
+        context: docker
+        build-args: |
+          JELLYFIN_TAG=${{ matrix.jellyfin-version }}
         push: true
         tags: ${{ env.REGISTRY}}/${{ github.repository.owner }}/jellyfin-intro-skipper:${{ steps.web-commit.outputs.commit }}
         provenance: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -77,7 +77,19 @@ jobs:
         path: web/dist.tar.gz
         if-no-files-found: error
 
-    - name: Publish container
+    # Extract metadata (tags, labels) for Docker
+    # https://github.com/docker/metadata-action
+    - name: Extract Docker metadata
+      id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type-raw,value=${{ steps.web-commit.outputs.commit }}
+          type=raw,value=latest,enable={{is_default_branch}}
+          type=semver,pattern={{version}},value=${{ matrix.jellyfin-version }
+
+    - name: Publish container image
       uses: docker/build-push-action@v4.0.0
       with:
         file: docker/Dockerfile
@@ -85,5 +97,6 @@ jobs:
         build-args: |
           JELLYFIN_TAG=${{ matrix.jellyfin-version }}
         push: true
-        tags: ${{ env.REGISTRY}}/${{ github.repository.owner }}/jellyfin-intro-skipper:${{ steps.web-commit.outputs.commit }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
         provenance: false

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -77,7 +77,11 @@ jobs:
     - name: Setup Docker buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Login to GHCR
+
+    # Login against a Docker registry except on PR
+    # https://github.com/docker/login-action
+    - name: Log into ghcr.io registry
+      if: github.event_name != 'pull_request'
       uses: docker/login-action@v2.1.0
       with:
         registry: ${{ env.REGISTRY }}
@@ -112,7 +116,7 @@ jobs:
           linux/amd64
           linux/arm/v7
           linux/arm64/v8
-        push: true
+        push: ${{ github.event_name != 'pull_request' }}
         pull: true
         no-cache: true
         cache-from: type=gha

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Upload web interface
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: jellyfin-web-${{ matrix.jellyfin-version }}+${{ steps.web-commit.outputs.commit }}.tar.gz
+          name: jellyfin-web-10.8.0+${{ steps.web-commit.outputs.commit }}.tar.gz
           path: web/dist.tar.gz
           if-no-files-found: error
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Upload web interface
         uses: actions/upload-artifact@v3.1.2
         with:
-          name: jellyfin-web-10.8.0+${{ steps.web-commit.outputs.commit }}.tar.gz
+          name: jellyfin-web-${{ matrix.jellyfin-version }}+${{ steps.web-commit.outputs.commit }}.tar.gz
           path: web/dist.tar.gz
           if-no-files-found: error
 

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,6 +9,7 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/jellyfin-intro-skipper
 
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -23,13 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Login to GHCR
-      uses: docker/login-action@v2.1.0
-      with:
-        registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v3
@@ -77,6 +71,19 @@ jobs:
         path: web/dist.tar.gz
         if-no-files-found: error
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Login to GHCR
+      uses: docker/login-action@v2.1.0
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     # Extract metadata (tags, labels) for Docker
     # https://github.com/docker/metadata-action
     - name: Extract Docker metadata
@@ -87,16 +94,27 @@ jobs:
         tags: |
           type-raw,value=${{ steps.web-commit.outputs.commit }}
           type=raw,value=latest,enable={{is_default_branch}}
-          type=semver,pattern={{version}},value=${{ matrix.jellyfin-version }
+          type=semver,pattern={{version}},value=${{ matrix.jellyfin-version }}
 
+    # Build and push Docker image with Buildx
+    # https://github.com/docker/build-push-action
     - name: Publish container image
+      id: build-and-push
       uses: docker/build-push-action@v4.0.0
       with:
         file: docker/Dockerfile
         context: docker
-        build-args: |
-          JELLYFIN_TAG=${{ matrix.jellyfin-version }}
-        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          JELLYFIN_TAG=${{ matrix.jellyfin-version }}
+        platforms: |
+          linux/amd64
+          linux/arm/v7
+          linux/arm64/v8
+        push: true
+        pull: true
+        no-cache: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
         provenance: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ jobs:
       run: .github/workflows/package.sh ${{ steps.tag.outputs.tag }}
 
     - name: Upload plugin archive
-      uses: actions/upload-artifact@v3.1.1
+      uses: actions/upload-artifact@v3.1.2
       with:
         name: intro-skipper-bundle-${{ steps.tag.outputs.tag }}.zip
         path: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
-FROM jellyfin/jellyfin:10.8.9
+ARG JELLYFIN_TAG=10.8.9
+FROM jellyfin/jellyfin:${JELLYFIN_TAG}
 
 COPY dist/ /jellyfin/jellyfin-web/


### PR DESCRIPTION
Following on commit [49be2f0](https://github.com/ConfusedPolarBear/intro-skipper/commit/49be2f02408ec4f853b6668b11637f6c5cdaf981), I decided to do additional work to try and improve the `container.yml` GitHub Action.

The features I added:
- Multi-arch images for all OS/ARCH that are supported by the official [jellyfin/jellyfin](https://hub.docker.com/r/jellyfin/jellyfin) image:
    + linux/amd64
    + linux/arm/v7
    + linux/arm64/v8
- Add automated tags for container image including `latest` and current semver version.
- Add checks to ensure PRs can't publish images.
- Update versions for GH Actions.
- Auto-indent YAML.

This Pull Request possibly closes issues #103 and #128. 