### PR TITLE
Don't show prompt after the segment has ended

### DIFF
--- a/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
+++ b/ConfusedPolarBear.Plugin.IntroSkipper/Controllers/SkipIntroController.cs
@@ -91,6 +91,12 @@ public class SkipIntroController : ControllerBase
             segment.HideSkipPromptAt = segment.IntroStart + config.HidePromptAdjustment;
             segment.IntroEnd -= config.SecondsOfIntroToPlay;
 
+            // Don't show prompt after the segment has ended
+            if (segment.HideSkipPromptAt > segment.IntroEnd)
+            {
+                segment.HideSkipPromptAt = segment.IntroEnd;
+            }
+
             return segment;
         }
         catch (KeyNotFoundException)


### PR DESCRIPTION
If the user has `HidePromptAdjustment` set to a value larger then the intro length, the prompt would be visible after the intro has ended.

Additionally, setting this value to a ridiculously high number allows user to make the prompt visible until the end of the segment.

Related https://github.com/ConfusedPolarBear/intro-skipper/issues/131