### PR TITLE
Bump `jellyfin/jellyfin` base container to version 10.8.10

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        jellyfin-container-version: [10.8.9]
+        jellyfin-container-version: [10.8.10]
         jellyfin-web-version: [10.8.9]
 
     steps:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG JELLYFIN_TAG=10.8.9
+ARG JELLYFIN_TAG=10.8.10
 FROM jellyfin/jellyfin:${JELLYFIN_TAG}
 
 COPY dist/ /jellyfin/jellyfin-web/


### PR DESCRIPTION
Partially addresses issue #156

The jellyfin-container-version is updated to tag `jellyfin/jellyfin:10.8.10`. However additional work is still needed, the [web interface fork](https://github.com/ConfusedPolarBear/jellyfin-web/tree/intros) also needs to be updated to 10.8.10.

This work is necessary to close the CRITICAL SECURITY ADVISORIES. [GHSA-9p5f-5x8v-x65m](https://github.com/jellyfin/jellyfin/security/advisories/GHSA-9p5f-5x8v-x65m) and [GHSA-89hp-h43h-r5pq](https://github.com/jellyfin/jellyfin-web/security/advisories/GHSA-89hp-h43h-r5pq).